### PR TITLE
r 0.2.1 FIX version import issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 #
 
 # virtualenv prefix
+VIR_ENV_PRE   =
 ifdef VIRTUAL_ENV
 VIR_ENV_PRE   = $(VIRTUAL_ENV)/bin/
 else

--- a/docs/useful_links.rst
+++ b/docs/useful_links.rst
@@ -73,5 +73,6 @@ Misc.
 
 * How to schedule jobs on UNIX systems using `chrontab`: http://kvz.io/blog/2007/07/29/schedule-tasks-on-linux-using-crontab/
 * How to schedule larger cluster jobs using Condor: https://www.lsc-group.phys.uwm.edu/lscdatagrid/doc/condorview.html
+* How to determine what OS you are running on: http://stackoverflow.com/questions/394230/detect-the-os-from-a-bash-script
 * http://stackoverflow.com/questions/592620/check-if-a-program-exists-from-a-bash-script
 

--- a/geco_stat.py
+++ b/geco_stat.py
@@ -7,7 +7,9 @@ import datetime
 import h5py             # >=2.5.0
 import abc
 import numpy as np      # >=1.10.4
-from version import *
+
+# import the version numbers
+execfile('version.py')
 
 DEFAULT_BITRATE = 16384
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ from setuptools import setup, find_packages
 from codecs import open
 from os import path
 
-from version import __release__ as version
+# from version import __release__ as version
+execfile('version.py')
 
 here = path.abspath(path.dirname(__file__))
 
@@ -26,8 +27,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    # version=version.__release__,
-    version = version,
+    version = __release__,
 
     description='Diagnostic tools for the advanced LIGO timing distribution system.',
     long_description=long_description,

--- a/version.py
+++ b/version.py
@@ -1,3 +1,2 @@
 __version__ = '0.2'
-__release__ = '0.2.0'
-__all__ = ['__release__', '__version__']
+__release__ = '0.2.1'


### PR DESCRIPTION
for some reason you can't just import the 'version.py' file, but running
`execfile` on it is supposed to work. idk why this is, but let's see if
this fixes the issue..
