### PR TITLE
FIX Read The Docs build dependency problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,9 +107,9 @@ env:
 # Install a virtualenv to allow for local development and usage.
 	if ! [ -e "./env" ]; then virtualenv env; fi
 # Install some stuff required for pip packaging and development
-	$(PIP) install -U "pip>=1.4" "setuptools>=0.9" "wheel>=0.21" twine "ipython"
-# Install sphinx itself
-	$(PIP) install -U "sphinx"
+	$(PIP) install -U "pip>=1.4" "setuptools>=0.9" "wheel>=0.21" twine "ipython" mock
+# Install sphinx itself, plus the Read the Docs theme
+	$(PIP) install -U "sphinx" "sphinx_rtd_theme"
 # Install required packages
 	env/bin/pip install -U "numpy" "matplotlib" "h5py" "tendo"
 	@echo "\nDone setting up! To use the virtual environment interactively, run\n\n\tsource env/bin/activate\n\nto start working in this virtual environment, and run\n\n\tdeactivate\n\nwhen finished to return to your normal setup.\n\nFor nice documentation on virtualenv, visit:\nhttps://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,28 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, os.path.abspath('.'))
 
+# Mock modules as per RTF FAQ to avoid hard C dependencies
+# the below only works for Python3.3+
+# from unittest.mock import MagicMock
+# use this for Python<3.3
+from mock import Mock as MagicMock
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+        return Mock()
+
+# MOCK_MODULES = ['numpy', 'scipy', 'mpi4py', 'h5py']
+MOCK_MODULES = ['numpy', 'matplotlib', 'mpi4py', 'tendo']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
+# Use the 'Read the Docs' theme on home builds:
+on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+if on_rtd:
+    html_theme = 'default'
+else:
+    html_theme = 'sphinx_rtd_theme'
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/useful_links.rst
+++ b/docs/useful_links.rst
@@ -48,27 +48,43 @@ Packaging and Distribution using PyPI and pip
 Running a Python Script from the Command Line
 ---------------------------------------------
 
-* https://docs.python.org/2/tutorial/modules.html#executing-modules-as-scripts
+* `Simple execution of a module as a script`_ (not from a package, but in the
+  current directory).
 * http://stackoverflow.com/questions/34952745/how-can-one-enable-a-shell-command-line-argument-for-a-python-package-installed
-* How to make sure that only a single instance of your code is running:
-  http://blog.tplus1.com/blog/2012/08/08/python-allow-only-one-running-instance-of-a-script/
-* A stackoverflow question on the topic with some nice alternative approaches:
-  http://stackoverflow.com/questions/380870/python-single-instance-of-program
-* Documentation on ``sys.excepthook``, used to call cleanup code right before
-  exiting when your program crashes: https://docs.python.org/2/library/sys.html
+* `How to make sure that only a single instance of your code is running`_.
+* `A stackoverflow question on the topic with some nice alternative approaches`_.
+* Documentation on ``sys.excepthook``,
+  `used to call cleanup code right before exiting when your program crashes`_.
+
+.. _Simple execution of a module as a script: https://docs.python.org/2/tutorial/modules.html#executing-modules-as-scripts
+.. _How to make sure that only a single instance of your code is running: http://blog.tplus1.com/blog/2012/08/08/python-allow-only-one-running-instance-of-a-script/
+.. _A stackoverflow question on the topic with some nice alternative approaches: http://stackoverflow.com/questions/380870/python-single-instance-of-program
+.. _used to call cleanup code right before exiting when your program crashes: https://docs.python.org/2/library/sys.html
 
 Using Read the Docs for Documentation
 -------------------------------------
 
-* https://read-the-docs.readthedocs.org/en/latest/getting_started.html
-* Astropy is a very good (and thorough) example of advanced Read The Docs
-  support in Python: https://github.com/astropy/astropy
+* `Official getting started guide`_.
+* `Astropy`_ is a very good (and thorough) example of advanced Read The Docs
+  support in Python.
+* `Official solution`_ regarding how to fix Read the Docs build failures resulting
+  from hard c dependencies (like h5py requiring HDF5).
+* `Example`_ of the above.
+* `Using the official Read the Docs Theme`_ in your homemade documentation.
+
+.. _Official solution: http://read-the-docs.readthedocs.org/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
+.. _Official getting started guide: https://read-the-docs.readthedocs.org/en/latest/getting_started.html
+.. _Astropy: https://github.com/astropy/astropy
+.. _Example: https://github.com/astropy/halotools/issues/154
+.. _Using the official Read the Docs Theme: https://github.com/snide/sphinx_rtd_theme
 
 Writing in Restructured Text (reST)
 -----------------------------------
 
-* I'm used to markdown, so this comparison of Restructured Text (reST) was very
-  helpful: http://www.unexpected-vortices.com/doc-notes/markdown-and-rest-compared.html
+* I'm used to markdown, so `this comparison`_ of Restructured Text (reST) was
+  very helpful.
+
+.. _this comparison: http://www.unexpected-vortices.com/doc-notes/markdown-and-rest-compared.html
 
 Python
 ------


### PR DESCRIPTION
FIX RTD can't build extensions that rely on hard c code, like `h5py`. Fix this
by creating mock modules for these tests (which is not such a bad idea
anyway for the sake of unit testing and should be implemented elsewhere
when I find the time). As part of this fix, create a separate, empty
`docs/requirements.rtd.txt` file, which must be explicitly selected as
the RTD requirements file on the Read The Docs project page.

ADD the RTD theme to doc builds initiated on this machine. Makes it easier to
see what the final product will look like.
